### PR TITLE
Fix parsing of subnet config from consul

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ aware of when modifying this file._
 DiscoverySubnets = ""
 
 # Maximum simultaneous network probes
-ProbeAsyncLimit = "1000"
+ProbeAsyncLimit = "5000"
 
 # Maximum amount of seconds to wait for each IP probe before timing out.
 # This will also be the minimum time the discovery process can take.

--- a/cmd/res/configuration.toml
+++ b/cmd/res/configuration.toml
@@ -62,7 +62,7 @@ File = ''
 DiscoverySubnets = ""
 
 # Maximum simultaneous network probes
-ProbeAsyncLimit = "1000"
+ProbeAsyncLimit = "5000"
 
 # Maximum amount of seconds to wait for each IP probe before timing out.
 # This will also be the minimum time the discovery process can take.

--- a/internal/driver/config_test.go
+++ b/internal/driver/config_test.go
@@ -18,7 +18,7 @@ func testConfig() map[string]string {
 	// NOTE: If you change this, you MUST update `TestLoad`!
 	return map[string]string{
 		"DiscoverySubnets":           "127.0.0.1/32,127.0.1.1/32",
-		"ProbeAsyncLimit":            "40",
+		"ProbeAsyncLimit":            "2257",
 		"ProbeTimeoutSeconds":        "5",
 		"ScanPort":                   "5084",
 		"MaxDiscoverDurationSeconds": "100",
@@ -33,13 +33,14 @@ func TestLoad(t *testing.T) {
 	}
 
 	c := driverCfg
-	if c.ProbeAsyncLimit != 40 ||
+	subnets := strings.Split(c.DiscoverySubnets, ",")
+	if c.ProbeAsyncLimit != 2257 ||
 		c.ProbeTimeoutSeconds != 5 ||
 		c.ScanPort != "5084" ||
 		c.MaxDiscoverDurationSeconds != 100 ||
-		len(c.DiscoverySubnets) != 2 ||
-		c.DiscoverySubnets[0] != "127.0.0.1/32" ||
-		c.DiscoverySubnets[1] != "127.0.1.1/32" {
+		len(subnets) != 2 ||
+		subnets[0] != "127.0.0.1/32" ||
+		subnets[1] != "127.0.1.1/32" {
 
 		t.Errorf("One of the value fields is incorrect.\nOriginal: %+v\nParsed: %+v", cfg, driverCfg)
 	}

--- a/internal/driver/discover.go
+++ b/internal/driver/discover.go
@@ -14,6 +14,7 @@ import (
 	dsModels "github.com/edgexfoundry/device-sdk-go/pkg/models"
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
 	"github.com/pkg/errors"
+	"math"
 	"math/bits"
 	"net"
 	"strconv"
@@ -113,7 +114,8 @@ func autoDiscover(ctx context.Context, params discoverParams) []dsModels.Discove
 	if estimatedProbes < asyncLimit {
 		asyncLimit = estimatedProbes
 	}
-	driver.lc.Debug(fmt.Sprintf("total estimated network probes: %d, async limit: %d", estimatedProbes, asyncLimit))
+	driver.lc.Debug(fmt.Sprintf("total estimated network probes: %d, async limit: %d, probe timeout: %v, total estimated time: %v",
+		estimatedProbes, asyncLimit, params.timeout, time.Duration(math.Ceil(float64(estimatedProbes)/float64(asyncLimit)))*params.timeout))
 
 	ipCh := make(chan uint32, asyncLimit)
 	resultCh := make(chan *discoveryInfo)

--- a/internal/driver/discover_test.go
+++ b/internal/driver/discover_test.go
@@ -44,7 +44,7 @@ func TestMain(m *testing.M) {
 func makeParams() discoverParams {
 	return discoverParams{
 		subnets:    []string{"127.0.0.1/32"},
-		asyncLimit: 1000,
+		asyncLimit: 5000,
 		timeout:    1 * time.Second,
 		scanPort:   "59923",
 	}

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -822,7 +822,8 @@ func (d *Driver) Discover() {
 func (d *Driver) discover(ctx context.Context) {
 	d.configMu.RLock()
 	params := discoverParams{
-		subnets:    d.config.DiscoverySubnets,
+		// split the comma separated string here to avoid issues with EdgeX's Consul implementation
+		subnets:    strings.Split(d.config.DiscoverySubnets, ","),
 		asyncLimit: d.config.ProbeAsyncLimit,
 		timeout:    time.Duration(d.config.ProbeTimeoutSeconds) * time.Second,
 		scanPort:   d.config.ScanPort,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## What is the current behavior?

Discover crashes when `DiscoverySubnets` has more than one subnet specified.

## What is the new behavior?

- Split `DiscoverySubnets` into string slice based on commas.
- Increase default async probe limit to `5,000`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
