### PR TITLE
fix(script): give DEBUG a default value of 0

### DIFF
--- a/bin/auto-configure.sh
+++ b/bin/auto-configure.sh
@@ -28,6 +28,7 @@
 set -eu
 
 # If ran with DEBUG=1, enable bash command tracing
+DEBUG=${DEBUG:-0}
 if [ "${DEBUG}" == "1" ]; then
     set -x
 fi


### PR DESCRIPTION

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Auto-configure script crashes if DEBUG does not contain a value (due to `set -u`)

## What is the new behavior?
DEBUG is defaulted to 0
